### PR TITLE
Set appropriate MIME type for .js files

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -8,11 +8,15 @@ from app.routers import upload, twoforms, unsplash, accordion
 from dotenv import load_dotenv
 load_dotenv()
 
+import mimetypes
+mimetypes.init()
+
 app = FastAPI()
 
 
 templates = Jinja2Templates(directory="templates")
 
+mimetypes.add_type('application/javascript', '.js')
 app.mount("/static", StaticFiles(directory="static"), name="static")
 
 app.include_router(upload.router)


### PR DESCRIPTION
I received the following error when running locally.

```
Failed to load module script: The server responded with a non-JavaScript MIME type of "text/plain".
Strict MIME type checking is enforced for module scripts per HTML spec.
```

All the `*.js` files were served with MIME type `text/plain`. With this fix they are properly served as `application/javascript`.